### PR TITLE
Fix ArgumentError when updating the ticket status

### DIFF
--- a/lib/reopen_issues_by_mail/mail_handler_patch.rb
+++ b/lib/reopen_issues_by_mail/mail_handler_patch.rb
@@ -18,7 +18,7 @@ module ReopenIssuesByMail
           JournalDetail.create(:journal => journal, :property => "attr",
                                :prop_key => "status_id", :value => status_id,
                                :old_value => issue.status_id)
-          Issue.update_all({:status_id => status_id}, {:id => issue.id})
+          Issue.where(:id => issue.id).update_all({:status_id => status_id})
           logger.info "MailHandler: reopening issue ##{issue.id}" if logger
         end
         journal.reload


### PR DESCRIPTION
This fixes 'ArgumentError (wrong number of arguments (given 2, expected
1)):', see https://progress.opensuse.org/issues/80580 for details.