### PR TITLE
Update for Redmine 5

### DIFF
--- a/lib/reopen_issues_by_mail/mail_handler_patch.rb
+++ b/lib/reopen_issues_by_mail/mail_handler_patch.rb
@@ -3,7 +3,8 @@ module ReopenIssuesByMail
     def self.included(base)
       base.send(:include, InstanceMethods)
       base.class_eval do
-        alias_method_chain :receive_issue_reply, :reopen_issues_by_mail
+        alias_method :receive_issue_reply_without_reopen_issues_by_mail, :receive_issue_reply
+        alias_method :receive_issue_reply, :receive_issue_reply_with_reopen_issues_by_mail
       end
     end
 
@@ -14,11 +15,11 @@ module ReopenIssuesByMail
         issue = Issue.find_by_id(issue_id)
         return unless issue
         if issue.closed?
-          status_id = IssueStatus.default.id
+          status_id = 1 # ID of the status you want to set (find it in the Administration panel by inspecting the hyperlink of the desired status under "Issue statuses")
           JournalDetail.create(:journal => journal, :property => "attr",
                                :prop_key => "status_id", :value => status_id,
                                :old_value => issue.status_id)
-          Issue.where(:id => issue.id).update_all({:status_id => status_id})
+          Issue.where(:id => issue_id).update_all(:status_id => status_id)
           logger.info "MailHandler: reopening issue ##{issue.id}" if logger
         end
         journal.reload


### PR DESCRIPTION
This imports the code from https://www.redmine.org/boards/2/topics/59807 to resolve errors with modern versions of Redminy/Ruby:

```
Jul 23 01:42:00 progressoo bundle.ruby2.7[10056]: NoMethodError: undefined method `alias_method_chain' for MailHandler:Class
Jul 23 01:42:00 progressoo bundle.ruby2.7[10056]: Did you mean?  alias_method

Jul 23 01:45:29 progressoo bundle.ruby2.7[10673]: bundler: failed to load command: /usr/bin/unicorn_rails.ruby2.7 (/usr/bin/unicorn_rails.ruby2.7)
Jul 23 01:45:29 progressoo bundle.ruby2.7[10673]: NameError: undefined method `reopen_issues_by_mail' for class `MailHandler'
```